### PR TITLE
Validate IContextView on extensions that depend on it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 
 - Update pixi.js to version 4.6.1 (see #33).
 
+- Validate IContextView on extensions that depend on it (see #34).
+
 - Update dev dependencies to latest version.
 
 ### [v0.1.0](https://github.com/RobotlegsJS/RobotlegsJS-Pixi/releases/tag/0.1.0) - 2017-11-13

--- a/src/robotlegs/bender/extensions/contextView/impl/ContextView.ts
+++ b/src/robotlegs/bender/extensions/contextView/impl/ContextView.ts
@@ -24,7 +24,11 @@ export class ContextView implements IContextView {
      * @param view The root Container for this Context
      */
     constructor(view: Container) {
-        this._view = view;
+        if (view !== null && view !== undefined) {
+            this._view = view;
+        } else {
+            throw new Error("View can't be null or undefined");
+        }
     }
 
     /*============================================================================*/

--- a/src/robotlegs/bender/extensions/viewManager/StageCrawlerExtension.ts
+++ b/src/robotlegs/bender/extensions/viewManager/StageCrawlerExtension.ts
@@ -79,9 +79,7 @@ export class StageCrawlerExtension implements IExtension {
             let contextView: IContextView = this._injector.get<IContextView>(
                 IContextView
             );
-            if (contextView.view) {
-                this.scanContainer(contextView.view);
-            }
+            this.scanContainer(contextView.view);
         } else {
             this._logger.error(
                 "A ContextView must be installed if you install the StageCrawlerExtension."

--- a/src/robotlegs/bender/extensions/viewManager/StageCrawlerExtension.ts
+++ b/src/robotlegs/bender/extensions/viewManager/StageCrawlerExtension.ts
@@ -72,14 +72,20 @@ export class StageCrawlerExtension implements IExtension {
     }
 
     private scanContextView(): void {
-        this._logger.debug(
-            "ViewManager is not installed. Checking the ContextView..."
-        );
-        let contextView: IContextView = this._injector.get<IContextView>(
-            IContextView
-        );
-        if (contextView.view) {
-            this.scanContainer(contextView.view);
+        if (this._injector.isBound(IContextView)) {
+            this._logger.debug(
+                "ViewManager is not installed. Checking the ContextView..."
+            );
+            let contextView: IContextView = this._injector.get<IContextView>(
+                IContextView
+            );
+            if (contextView.view) {
+                this.scanContainer(contextView.view);
+            }
+        } else {
+            this._logger.error(
+                "A ContextView must be installed if you install the StageCrawlerExtension."
+            );
         }
     }
 

--- a/test/robotlegs/bender/bundles/pixi/pixiBundle.test.ts
+++ b/test/robotlegs/bender/bundles/pixi/pixiBundle.test.ts
@@ -1,0 +1,72 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017 RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
+import "../../../../entry";
+
+import { assert } from "chai";
+
+import { Container } from "pixi.js";
+
+import { IContext, Context, LogLevel } from "@robotlegsjs/core";
+
+import {
+    IContextView,
+    IMediatorMap,
+    IViewManager,
+    ContextView,
+    PixiBundle
+} from "../../../../../src";
+
+import { ContainerRegistry } from "../../../../../src/robotlegs/bender/extensions/viewManager/impl/ContainerRegistry";
+
+import { CallbackLogTarget } from "../../extensions/contextView/support/CallbackLogTarget";
+import { LogParams } from "../../extensions/contextView/support/LogParams";
+
+describe("PixiBundle", () => {
+    let context: IContext;
+
+    afterEach(() => {
+        if (context.initialized) {
+            context.destroy();
+        }
+        context = null;
+    });
+
+    it("bundle_is_properly_installed_into_context", () => {
+        context = new Context();
+        context
+            .install(PixiBundle)
+            .configure(new ContextView(new Container()))
+            .initialize();
+
+        // Verify if all extensions are installed
+        assert.isTrue(context.injector.isBound(IContextView));
+        assert.isTrue(context.injector.isBound(ContainerRegistry));
+        assert.isTrue(context.injector.isBound(IViewManager));
+        assert.isTrue(context.injector.isBound(IMediatorMap));
+    });
+
+    it("bundle_logs_an_error_message_when_context_view_is_not_provided", () => {
+        let errorLogged: boolean = false;
+        let logTarget: CallbackLogTarget = new CallbackLogTarget(
+            (log: LogParams) => {
+                if (
+                    log.source instanceof PixiBundle &&
+                    log.level === LogLevel.ERROR
+                ) {
+                    errorLogged =
+                        log.message === "PixiBundle requires IContextView.";
+                }
+            }
+        );
+
+        context = new Context();
+        context.addLogTarget(logTarget);
+        context.install(PixiBundle).initialize();
+        assert.isTrue(errorLogged);
+    });
+});

--- a/test/robotlegs/bender/extensions/contextView/impl/contextView.test.ts
+++ b/test/robotlegs/bender/extensions/contextView/impl/contextView.test.ts
@@ -31,4 +31,18 @@ describe("ContextView", () => {
         assert.isNotNull(contextView.view);
         assert.equal(contextView.view, container);
     });
+
+    it("ContextView_throws_a_error_when_view_is_null", () => {
+        function inicializeContextViewWithNullView(): void {
+            contextView = new ContextView(null);
+        }
+        assert.throws(inicializeContextViewWithNullView, Error);
+    });
+
+    it("ContextView_throws_a_error_when_view_is_undefined", () => {
+        function inicializeContextViewWithUndefinedView(): void {
+            contextView = new ContextView(undefined);
+        }
+        assert.throws(inicializeContextViewWithUndefinedView, Error);
+    });
 });

--- a/test/robotlegs/bender/extensions/mediatorMap/mediatorMapExtension.test.ts
+++ b/test/robotlegs/bender/extensions/mediatorMap/mediatorMapExtension.test.ts
@@ -50,6 +50,17 @@ describe("MediatorMapExtension", () => {
         assert.instanceOf(mediatorMap, MediatorMap);
     });
 
+    it("mediatorMap_is_mapped_into_injector_on_initialize_when_view_manager_is_not_installed", () => {
+        let mediatorMap: IMediatorMap = null;
+        context.install(MediatorMapExtension);
+        context.whenInitializing(function(): void {
+            mediatorMap = context.injector.get<IMediatorMap>(IMediatorMap);
+        });
+        context.initialize();
+        assert.isNotNull(mediatorMap);
+        assert.instanceOf(mediatorMap, MediatorMap);
+    });
+
     it("mediatorMap_is_unmapped_from_injector_on_destroy", () => {
         context.install(ViewManagerExtension, MediatorMapExtension);
         context.afterDestroying(function(): void {

--- a/test/robotlegs/bender/extensions/viewManager/stageCrawlerExtension.test.ts
+++ b/test/robotlegs/bender/extensions/viewManager/stageCrawlerExtension.test.ts
@@ -130,4 +130,33 @@ describe("StageCrawlerExtension", () => {
         assert.isTrue(viewManagerIsNotInstalledLogged);
         assert.isTrue(scanningContainerLogged);
     });
+
+    it("extension_logs_error_when_context_initialized_without_contextView", () => {
+        let contextViewIsNotInstalledLogged: boolean = false;
+        let logTarget: CallbackLogTarget = new CallbackLogTarget(
+            (log: LogParams) => {
+                if (
+                    log.source instanceof StageCrawlerExtension &&
+                    log.level === LogLevel.ERROR
+                ) {
+                    if (!contextViewIsNotInstalledLogged) {
+                        contextViewIsNotInstalledLogged =
+                            log.message ===
+                            "A ContextView must be installed if you install the StageCrawlerExtension.";
+                    }
+                }
+            }
+        );
+        let handler: IViewHandler = new CallbackViewHandler();
+        let registry: ContainerRegistry = new ContainerRegistry();
+
+        registry.addContainer(container).addHandler(handler);
+
+        context.logLevel = LogLevel.DEBUG;
+        context.install(ContextViewExtension, StageCrawlerExtension);
+        context.injector.bind(ContainerRegistry).toConstantValue(registry);
+        context.addLogTarget(logTarget);
+        context.initialize();
+        assert.isTrue(contextViewIsNotInstalledLogged);
+    });
 });


### PR DESCRIPTION
- **ContextView** throws a error when **view** is **null** or **undefined**.

- **PixiBundle** is only initialized when **IContextView** is provided.

- **StageCrawlerExtension** is only initialized when **IContextView** is provided.