### PR TITLE
Add ContextView handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
 
 ## Robotlegs-Pixi 0.1.0
 
+### v0.1.2
+
+- Add ContextView handler (see #35).
+
 ### [v0.1.1](https://github.com/RobotlegsJS/RobotlegsJS-Pixi/releases/tag/0.1.1) - 2017-11-20
 
 - Update pixi.js to version 4.6.1 (see #33).

--- a/src/robotlegs/bender/bundles/pixi/PixiBundle.ts
+++ b/src/robotlegs/bender/bundles/pixi/PixiBundle.ts
@@ -5,9 +5,10 @@
 //  in accordance with the terms of the license agreement accompanying it.
 // ------------------------------------------------------------------------------
 
-import { IBundle, IContext, ILogger } from "@robotlegsjs/core";
+import { IBundle, IContext, ILogger, instanceOfType } from "@robotlegsjs/core";
 
 import { IContextView } from "../../extensions/contextView/api/IContextView";
+import { ContextView } from "../../extensions/contextView/impl/ContextView";
 import { ContextViewListenerConfig } from "../../extensions/contextView/impl/ContextViewListenerConfig";
 
 import { ContextViewExtension } from "../../extensions/contextView/ContextViewExtension";
@@ -49,6 +50,10 @@ export class PixiBundle implements IBundle {
             StageCrawlerExtension
         );
 
+        this._context.addConfigHandler(
+            instanceOfType(ContextView),
+            this.handleContextView.bind(this)
+        );
         this._context.whenInitializing(this.whenInitializing.bind(this));
         this._context.afterDestroying(this.afterDestroying.bind(this));
     }
@@ -57,10 +62,12 @@ export class PixiBundle implements IBundle {
     /* Private Functions                                                          */
     /*============================================================================*/
 
+    private handleContextView(): void {
+        this._context.configure(ContextViewListenerConfig);
+    }
+
     private whenInitializing(): void {
-        if (this._context.injector.isBound(IContextView)) {
-            this._context.configure(ContextViewListenerConfig);
-        } else {
+        if (!this._context.injector.isBound(IContextView)) {
             this._logger.error("PixiBundle requires IContextView.");
         }
     }


### PR DESCRIPTION
- The **PixiBundle** depends on an instance of **ContextView**, so it will map the **IContextView** only when a **ContextView** is provided. Using a **ConfigHandler** to do this solves the issue of not having a **IContextView** mapped during initialization since the config handlers are processed before the initialization process.