### PR TITLE
Use rimraf to clean-up temporary folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 
 - Update pixi.js to version 4.7.3 (see #52).
 
+- Use `rimraf` instead of `rm -rf` (see #55).
+
 - Update Prettier rules (see #54).
 
 - Update dev dependencies to latest version.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "mocha": "mocha test/**/*.test.ts --require ts-node/register",
     "autoformat": "prettier --config .prettierrc --write {src,test,example,definitions}/**/*.ts",
     "tslint-check": "tslint-config-prettier-check ./tslint.json",
-    "clean-up": "rm -rf .nyc_output && rm -rf coverage && rm -rf lib",
+    "clean-up": "rimraf .nyc_output && rimraf coverage && rimraf lib",
     "prepare": "npm run clean-up && tsc -d",
     "prepublishOnly": "publish-please guard",
     "publish-please": "npm run autoformat && npm run clean-up && npm run test && publish-please"


### PR DESCRIPTION
Use `rimraf` instead of `rm -rf` to clean-up temporary folders.