### PR TITLE
Update pixi.js to the latest version 🚀

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 - Update eventemitter3 to version 3.1.0 (see #52).
 
-- Update pixi.js to version 4.7.3 (see #52).
+- Update pixi.js to version 4.8.0 (see #59).
 
 - Enforce TSLint rules (see #58).
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@robotlegsjs/core": "^0.1.3",
     "eventemitter3": "^3.1.0",
-    "pixi.js": "^4.7.3"
+    "pixi.js": "^4.8.0"
   },
   "devDependencies": {
     "@types/bluebird": "^3.5.20",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5157,9 +5157,9 @@ pixi-gl-core@^1.1.4:
   version "1.1.4"
   resolved "https://registry.npmjs.org/pixi-gl-core/-/pixi-gl-core-1.1.4.tgz#8b4b5c433b31e419bc379dc565ce1b835a91b372"
 
-pixi.js@^4.7.3:
-  version "4.7.3"
-  resolved "https://registry.npmjs.org/pixi.js/-/pixi.js-4.7.3.tgz#46565cd013275f072da839e108184ad92b853745"
+pixi.js@^4.8.0:
+  version "4.8.0"
+  resolved "https://registry.npmjs.org/pixi.js/-/pixi.js-4.8.0.tgz#4b681140f4c40fdf75cbb773d69699da53a62fd5"
   dependencies:
     bit-twiddle "^1.0.2"
     earcut "^2.1.3"


### PR DESCRIPTION
Update **pixi.js** to version **4.8.0**.