### PR TITLE
Only dispatch 'added' or 'removed' events when view is related to current stage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@
 
 - Adopts year-agnostic copyright message (see #70).
 
+- Only dispatch 'added' or 'removed' events when view is related to current stage (see #67, #68, #72).
+
 - Update dev dependencies to latest version.
 
 ### [v0.1.2](https://github.com/RobotlegsJS/RobotlegsJS-Pixi/releases/tag/0.1.2) - 2017-11-23

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "author": "RobotlegsJS",
   "contributors": [
     "Endel Dreyer <endel.dreyer@gmail.com>",
+    "Mateusz Szymik <adde197@gmail.com>",
     "Tiago Schenkel <tiago.schenkel@gmail.com>"
   ],
   "license": "MIT",

--- a/src/robotlegs/bender/extensions/contextView/pixiPatch/pixi-patch.ts
+++ b/src/robotlegs/bender/extensions/contextView/pixiPatch/pixi-patch.ts
@@ -16,8 +16,7 @@ import "./contains-patch";
 
 import PIXI = require("pixi.js");
 
-
-interface AddedEventEmitable {
+interface IAddedEventEmitable {
     __addedEventEmited: boolean;
 }
 
@@ -32,7 +31,7 @@ function isConnectedToStage(stage: PIXI.Container, object: PIXI.DisplayObject): 
 }
 
 function addedEventAlreadyEmited(object: PIXI.DisplayObject): boolean {
-    return (<any>object as AddedEventEmitable).__addedEventEmited;
+    return ((<any>object) as IAddedEventEmitable).__addedEventEmited;
 }
 
 function emitAddedEvent(stage: PIXI.Container, target: PIXI.DisplayObject): void {
@@ -41,7 +40,7 @@ function emitAddedEvent(stage: PIXI.Container, target: PIXI.DisplayObject): void
     }
 
     stage.emit("added", { target });
-    (<any>target as AddedEventEmitable).__addedEventEmited = true;
+    ((<any>target) as IAddedEventEmitable).__addedEventEmited = true;
 
     if (target instanceof PIXI.Container) {
         target.children.forEach(child => emitAddedEvent(stage, child));
@@ -66,7 +65,6 @@ export function applyPixiPatch(stage: PIXI.Container) {
             if (isConnectedToStage(stage, object)) {
                 emitAddedEvent(stage, object);
             }
-
         }
         return child;
     };
@@ -84,7 +82,7 @@ export function applyPixiPatch(stage: PIXI.Container) {
         for (let i = 0, len = child.length; i < len; i++) {
             removeChild.call(this, child[i]);
             stage.emit("removed", { target: child[i] });
-            (<any>child[i] as AddedEventEmitable).__addedEventEmited = false;
+            ((<any>child[i]) as IAddedEventEmitable).__addedEventEmited = false;
         }
         return child[0];
     };
@@ -94,7 +92,7 @@ export function applyPixiPatch(stage: PIXI.Container) {
 
         for (let child of removedChildren) {
             stage.emit("removed", { target: child });
-            (<any>child as AddedEventEmitable).__addedEventEmited = false;
+            ((<any>child) as IAddedEventEmitable).__addedEventEmited = false;
         }
 
         return removedChildren;
@@ -103,7 +101,7 @@ export function applyPixiPatch(stage: PIXI.Container) {
     PIXI.Container.prototype.removeChildAt = function(index): PIXI.DisplayObject {
         let child = removeChildAt.call(this, index);
         stage.emit("removed", { target: child });
-        (<any>child as AddedEventEmitable).__addedEventEmited = false;
+        ((<any>child) as IAddedEventEmitable).__addedEventEmited = false;
         return child;
     };
 }

--- a/test/robotlegs/bender/extensions/contextView/pixiPatch/pixiPatch.test.ts
+++ b/test/robotlegs/bender/extensions/contextView/pixiPatch/pixiPatch.test.ts
@@ -9,7 +9,7 @@ import "../../../../../entry";
 
 import { assert } from "chai";
 
-import { Container } from "pixi.js";
+import { Container, DisplayObject } from "pixi.js";
 
 import { applyPixiPatch } from "../../../../../../src/robotlegs/bender/extensions/contextView/pixiPatch/pixi-patch";
 
@@ -124,6 +124,60 @@ describe("PixiPatch", () => {
         assert.equal(count, 5);
     });
 
+    it("addChild_stage_capture_added_events_on_nested_hierarchy_added_in_reverse", () => {
+        applyPixiPatch(stage);
+
+        let container1: Container = new Container();
+        let container2: Container = new Container();
+        let container3: Container = new Container();
+        let container4: Container = new Container();
+        let container5: Container = new Container();
+
+        let count: number = 0;
+
+        stage.on("added", () => {
+            count++;
+        });
+
+        container4.addChild(container5);
+        container3.addChild(container4);
+        container2.addChild(container3);
+        container1.addChild(container2);
+        stage.addChild(container1);
+
+        assert.equal(count, 5);
+    });
+
+    it("addChild_stage_capture_added_events_on_nested_hierarchy_with_display_objects", () => {
+        applyPixiPatch(stage);
+
+        let container: Container = new Container();
+        let containerL: Container = new Container();
+        let containerR: Container = new Container();
+
+        let childL1: DisplayObject = new DisplayObject();
+        let childL2: DisplayObject = new DisplayObject();
+        let childR1: DisplayObject = new DisplayObject();
+        let childR2: DisplayObject = new DisplayObject();
+
+        let count: number = 0;
+
+        stage.on("added", () => {
+            count++;
+        });
+
+        containerL.addChild(childL1);
+        containerL.addChild(childL2);
+        containerR.addChild(childR1);
+        containerR.addChild(childR2);
+
+        container.addChild(containerL, containerR);
+        assert.equal(count, 0);
+
+        stage.addChild(container);
+        assert.equal(count, 7);
+    });
+
     it("addChildAt_return_reference_of_child_added", () => {
         let child: Container = new Container();
         applyPixiPatch(stage);
@@ -175,6 +229,31 @@ describe("PixiPatch", () => {
         container3.addChildAt(container4, 0);
         container4.addChildAt(container5, 0);
 
+        assert.equal(count, 5);
+    });
+
+    it("addChildAt_stage_capture_added_events_on_nested_hierarchy_added_in_reverse", () => {
+        applyPixiPatch(stage);
+
+        let container1: Container = new Container();
+        let container2: Container = new Container();
+        let container3: Container = new Container();
+        let container4: Container = new Container();
+        let container5: Container = new Container();
+
+        let count: number = 0;
+
+        stage.on("added", () => {
+            count++;
+        });
+
+        container4.addChildAt(container5, 0);
+        container3.addChildAt(container4, 0);
+        container2.addChildAt(container3, 0);
+        container1.addChildAt(container2, 0);
+        assert.equal(count, 0);
+
+        stage.addChildAt(container1, 0);
         assert.equal(count, 5);
     });
 

--- a/test/robotlegs/bender/extensions/contextView/pixiPatch/pixiPatch.test.ts
+++ b/test/robotlegs/bender/extensions/contextView/pixiPatch/pixiPatch.test.ts
@@ -469,4 +469,60 @@ describe("PixiPatch", () => {
 
         assert.equal(count, 5);
     });
+
+    it("stage_does_not_capture_events_dispatched_in_another_stage", () => {
+        applyPixiPatch(stage);
+
+        let container1: Container = new Container();
+        let container2: Container = new Container();
+        let child1: DisplayObject = new DisplayObject();
+        let child2: DisplayObject = new DisplayObject();
+        let child3: DisplayObject = new DisplayObject();
+
+        let stageX: Container = new Container();
+
+        applyPixiPatch(stageX);
+
+        let containerX1: Container = new Container();
+        let containerX2: Container = new Container();
+        let childX1: DisplayObject = new DisplayObject();
+        let childX2: DisplayObject = new DisplayObject();
+        let childX3: DisplayObject = new DisplayObject();
+
+        let countAdded: number = 0;
+        let countRemoved: number = 0;
+
+        stage.on("added", () => {
+            countAdded++;
+        });
+
+        stage.on("removed", () => {
+            countRemoved++;
+        });
+
+        container2.addChildAt(child1, 0);
+        container2.addChildAt(child2, 1);
+        container2.addChildAt(child3, 2);
+        container1.addChild(container2);
+        stage.addChild(container1);
+
+        containerX2.addChildAt(childX1, 0);
+        containerX2.addChildAt(childX2, 1);
+        containerX2.addChildAt(childX3, 2);
+        containerX1.addChild(containerX2);
+        stageX.addChild(containerX1);
+
+        assert.equal(countAdded, 5);
+        assert.equal(countRemoved, 0);
+
+        container2.removeChildren(0, 2);
+        container1.removeChild(container2);
+        stage.removeChild(container1);
+
+        containerX2.removeChildren(0, 2);
+        containerX1.removeChild(containerX2);
+        stageX.removeChild(containerX1);
+
+        assert.equal(countRemoved, 5);
+    });
 });


### PR DESCRIPTION
Only dispatch **added** or **removed** events when a view is related to current stage.

Resolves #67, improving implementation provided by @fireveined in #68.