### PR TITLE
Move pixi.js and eventemitter3 libraries to peerDependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@
 
 - Only dispatch 'added' or 'removed' events when view is related to current stage (see #67, #68, #72).
 
+- Move `pixi.js` and `eventemitter3` libraries to **peerDependencies** (see #76).
+
 - Update dev dependencies to latest version.
 
 ## Robotlegs-Pixi 0.1.0

--- a/README.md
+++ b/README.md
@@ -27,10 +27,38 @@ Or using [Yarn](https://yarnpkg.com/en/):
 ```bash
 yarn add @robotlegsjs/pixi
 ```
+
+From version `0.2.0` of this package, the [PixiJS](https://github.com/pixijs/pixi.js) dependencies were moved to **peerDependencies**,
+allowing the final user to choose the desired version of the `pixi.js` library on each project.
+
+The `@robotlegsjs/pixi` package is compatible with versions between the `>=4.2.1 <5` version range of `pixi.js` library.
+
+Since each version of `pixi.js` library defines which version of `eventemitter3` library is being used, remember to also install the proper version of `eventemitter3` in your project.
+
+As example, when you would like to use the version `4.2.1` of `pixi.js` library, you can run:
+
+```bash
+npm install pixi.js@4.2.1 eventemitter3@^2.0.0 reflect-metadata --save
+```
+
+or
+
+```bash
+yarn add pixi.js@4.2.1 eventemitter3@^2.0.0 reflect-metadata --save
+```
+
+Then follow the [installation instructions](https://github.com/RobotlegsJS/RobotlegsJS/blob/master/README.md#installation) of **RobotlegsJS** library to complete the setup of your project.
+
 **Dependencies**
 
 + [RobotlegsJS](https://github.com/RobotlegsJS/RobotlegsJS)
++ [tslib](https://github.com/Microsoft/tslib)
+
+**Peer Dependencies**
+
 + [PixiJS](https://github.com/pixijs/pixi.js)
++ [eventemitter3](https://github.com/primus/eventemitter3)
++ [reflect-metadata](https://github.com/rbuckton/reflect-metadata)
 
 Usage
 ---
@@ -50,9 +78,9 @@ import { CircleView } from "./view/CircleView";
 
 class Main {
 
-    stage: PIXI.Container;
-    renderer: PIXI.CanvasRenderer | PIXI.WebGLRenderer;
-    context: Context;
+    private stage: PIXI.Container;
+    private renderer: PIXI.CanvasRenderer | PIXI.WebGLRenderer;
+    private context: Context;
 
     constructor () {
         this.renderer = PIXI.autoDetectRenderer(800, 600, {});
@@ -69,7 +97,7 @@ class Main {
         document.body.appendChild(this.renderer.view);
     }
 
-    render = () => {
+    public render = () => {
         this.renderer.render(this.stage);
         window.requestAnimationFrame(this.render);
     }
@@ -88,9 +116,16 @@ Running the example
 
 Run the following commands to run the example:
 
-```
+```bash
 npm install
 npm start
+```
+
+or:
+
+```bash
+yarn install
+yarn start
 ```
 
 License

--- a/package.json
+++ b/package.json
@@ -49,9 +49,12 @@
   "homepage": "https://github.com/RobotlegsJS/RobotlegsJS-Pixi#readme",
   "dependencies": {
     "@robotlegsjs/core": "^0.2.0",
-    "eventemitter3": "^3.1.0",
-    "pixi.js": "^4.8.0",
     "tslib": "^1.9.3"
+  },
+  "peerDependencies": {
+    "eventemitter3": "^2.0.0",
+    "pixi.js": "^4.2.1",
+    "reflect-metadata": "^0.1.12"
   },
   "devDependencies": {
     "@types/bluebird": "^3.5.23",
@@ -64,6 +67,7 @@
     "chai": "^4.1.2",
     "es6-map": "^0.1.5",
     "es6-symbol": "^3.1.1",
+    "eventemitter3": "^2.0.0",
     "glslify": "^6.2.1",
     "html-webpack-plugin": "^3.2.0",
     "imports-loader": "^0.8.0",
@@ -84,6 +88,7 @@
     "karma-sourcemap-writer": "^0.1.2",
     "karma-webpack": "^3.0.0",
     "mocha": "^5.2.0",
+    "pixi.js": "^4.8.1",
     "prettier": "^1.14.0",
     "publish-please": "^3.2.0",
     "reflect-metadata": "^0.1.12",
@@ -99,8 +104,5 @@
     "webpack": "^4.16.4",
     "webpack-cli": "^3.1.0",
     "webpack-dev-server": "^3.1.5"
-  },
-  "peerDependencies": {
-    "reflect-metadata": "^0.1.12"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2096,7 +2096,7 @@ eventemitter3@^2.0.0:
   version "2.0.3"
   resolved "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz#b5e1079b59fb5e1ba2771c0a993be060a58c99ba"
 
-eventemitter3@^3.0.0, eventemitter3@^3.1.0:
+eventemitter3@^3.0.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
 
@@ -5228,7 +5228,7 @@ pixi-gl-core@^1.1.4:
   version "1.1.4"
   resolved "https://registry.npmjs.org/pixi-gl-core/-/pixi-gl-core-1.1.4.tgz#8b4b5c433b31e419bc379dc565ce1b835a91b372"
 
-pixi.js@^4.8.0:
+pixi.js@^4.8.1:
   version "4.8.1"
   resolved "https://registry.npmjs.org/pixi.js/-/pixi.js-4.8.1.tgz#e35f370b0c635b5c542014d0649317d63d2ec7c4"
   dependencies:


### PR DESCRIPTION
Move `pixi.js` and `eventemitter3` libraries to **peerDependencies**, allowing the final user to choose the desired version of the `pixi.js` library on each project.